### PR TITLE
Escape all sql statements to avoid sql injections

### DIFF
--- a/core/entryController.js
+++ b/core/entryController.js
@@ -13,43 +13,43 @@ exports.getAll = function(req, res) {
         active = req.query.isActive || 1;
     db.getEntries(limit, offset, active, function(results, err){
         if(!err){
-             // format output where required
-             let out = [];
-             results.forEach(function(item){
-                 let obj = {};
+            // format output where required
+            let out = [];
+            results.forEach(function(item){
+                let obj = {};
 
-                 obj.id              = item.id;
-                 obj.email           = item.email;
-                 obj.firstname       = item.firstname;
-                 obj.lastname        = item.lastname;
-                 obj.message         = item.message;
-                 obj.country         = item.country;
-                 obj.ipv4            = item.ipv4;
-                 obj.ipv6            = item.ipv6;
-                 obj.email_confirmed = item.email_confirmed;
-                 obj.confirm_key     = item.confirm_key;
-                 obj.status          = item.status;
-                 obj.anon            = item.anon;
-                 obj.created_at      = item.created_at;
-                 obj.updated_at      = item.updated_at;
-                 obj.confirmed_at    = item.confirmed_at;
+                obj.id              = item.id;
+                obj.email           = item.email;
+                obj.firstname       = item.firstname;
+                obj.lastname        = item.lastname;
+                obj.message         = item.message;
+                obj.country         = item.country;
+                obj.ipv4            = item.ipv4;
+                obj.ipv6            = item.ipv6;
+                obj.email_confirmed = item.email_confirmed;
+                obj.confirm_key     = item.confirm_key;
+                obj.status          = item.status;
+                obj.anon            = item.anon;
+                obj.created_at      = item.created_at;
+                obj.updated_at      = item.updated_at;
+                obj.confirmed_at    = item.confirmed_at;
 
-                 if(item.image !== ''){
-                   obj.image = "https://" + req.hostname + "/uploads/"+item.image;
-                 }else{
-                     obj.image = '';
-                 }
+                if(item.image !== ''){
+                    obj.image = "https://" + req.hostname + "/uploads/"+item.image;
+                }else{
+                    obj.image = '';
+                }
 
 
-                 out.push(obj);
-             });
+                out.push(obj);
+            });
 
-             res.status(200).json({
-                 success : true,
-                 results : out,
-                 totalCount : results.length,
-                 page : offset
-             });
+            res.status(200).json({
+                success : true,
+                results : out,
+                totalCount : results.length,
+                page : offset
+            });
         }else{
             res.status(400).json({success : false, message : "error"});
         }
@@ -57,19 +57,19 @@ exports.getAll = function(req, res) {
 };
 
 exports.toggleStatus = function(req, res){
-      let form = new formidable.IncomingForm();
-      form.parse(req, function (err, fields) {
-          console.log(fields.id)
-            if(fields && fields.id !== undefined){
-                db.toggleEntryStatus(fields.id, fields.state, function(results, err){
-                      if(!err){
-                        res.status(200).json({success : true, message : "toggled status"});
-                      }else{
-                          res.status(400).json({success : false, message : "error"});
-                      }
-                })
-            }
-      });
+    let form = new formidable.IncomingForm();
+    form.parse(req, function (err, fields) {
+
+        if(fields && fields.id !== undefined){
+            db.toggleEntryStatus(fields.id, fields.state, function(results, err){
+                if(!err){
+                    res.status(200).json({success : true, message : "toggled status"});
+                }else{
+                    res.status(400).json({success : false, message : "error"});
+                }
+            })
+        }
+    });
 };
 
 exports.getCount = function(req, res) {
@@ -87,14 +87,14 @@ exports.getCount = function(req, res) {
 exports.verifyEntry = function(req, res) {
     db.verifyEntry(req.params.k, function(results, err){
         if(!err){
-          db.getUserByHash(req.params.k, function(results, err){
-            if(!err){
-              mailer.sendVerifySuccess({email : results[0].email, firstname : results[0].firstname});
-              res.redirect('https://human-connection.org/uhr-des-wandels/?ns=t');
-            }
-          });
+            db.getUserByHash(req.params.k, function(results, err){
+                if(!err){
+                    mailer.sendVerifySuccess({email : results[0].email, firstname : results[0].firstname});
+                    res.redirect('https://human-connection.org/uhr-des-wandels/?ns=t');
+                }
+            });
         }else{
-          res.redirect('https://human-connection.org/uhr-des-wandels/?ns=f');
+            res.redirect('https://human-connection.org/uhr-des-wandels/?ns=f');
         }
     });
 };
@@ -180,13 +180,13 @@ exports.createEntry = function(req, res) {
             fields["ipv4"]  = req.ip;
 
             if(hasFile){
-              fields["image"] = hasFile ? files[0].path.replace('uploads/', '') : '';
+                fields["image"] = hasFile ? files[0].path.replace('uploads/', '') : '';
 
-              let newFile = resize(files[0].path, 200, 200);
-              fs.unlinkSync(files[0].path);
-              newFile.toFile('uploads/'+fields["image"], (err, info) => {});
+                let newFile = resize(files[0].path, 200, 200);
+                fs.unlinkSync(files[0].path);
+                newFile.toFile('uploads/'+fields["image"], (err, info) => {});
             }else{
-              fields["image"] = '';
+                fields["image"] = '';
             }
 
             let hash = crypto.randomBytes(32).toString('hex');
@@ -194,14 +194,14 @@ exports.createEntry = function(req, res) {
 
             // save to db
             db.saveEntry(fields, function(err, results){
-              if(!err){
-                // send verification email
-                mailer.sendVerificationMail(hash, {email : fields.email, firstname : fields.firstname});
+                if(!err){
+                    // send verification email
+                    mailer.sendVerificationMail(hash, {email : fields.email, firstname : fields.firstname});
 
-                res.status(200).json({success : true});
-              }else{
-                res.status(400).json({success : false, message : "error"});
-              }
+                    res.status(200).json({success : true});
+                }else{
+                    res.status(400).json({success : false, message : "error"});
+                }
             });
         }
     });

--- a/core/restapi.js
+++ b/core/restapi.js
@@ -11,7 +11,6 @@ module.exports = function(app) {
     app.route('/entries/verify/:k').get(entryController.verifyEntry);
 
     // intercept request and check for api key
-
     app.use((req, res, next) => {
         let apiKey = req.get('API-Key');
         db.isValidApiKey(apiKey, function(results, err){


### PR DESCRIPTION
Escape all sql statements to avoid sql injections as this is not done… by default from node mysql package.

Contrary to the statement [here](https://github.com/Human-Connection/Clock-of-Change-API/blob/master/core/db.js#L161) the user input and thus most field are NOT automatically sanitized and escaped by node mysql. At least not in the way it was done until now.

See: https://www.npmjs.com/package/mysql#escaping-query-values and https://stackoverflow.com/questions/49015570/node-mysql-escaping-mysql-escape-mysql-escapeid (last answer) just to name a few.

This is why I had to change every sql statement accessing user input, so that is escaped and we don't suffer from sql inection attacks.