### PR TITLE
Fix getEntries by parsing parameters to integer, to prevent single qu…

### DIFF
--- a/core/db.js
+++ b/core/db.js
@@ -62,7 +62,7 @@ exports.getEntries = function(limit, offset, active, callback){
         }
 
         // make the query
-        connection.query(sql, [limit, offset], function(err, results) {
+        connection.query(sql, [parseInt(limit), parseInt(offset)], function(err, results) {
             connection.release();
             if(err) { callback(results, true); return; }
             callback(results, false);


### PR DESCRIPTION
Fix getEntries by parsing parameters to integer, to prevent single quotes for strings in MySQL limit and offset parameters, which leads to SQL errors.