### PR TITLE
Create new Docker network coc_network and let Docker services join

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ To run the Docker version, follow these steps:
 and open the directory in the console. Then run `git clone https://github.com/Human-Connection/Clock-of-Change-API.git` to clone the repository to this directory.
 2. Go to the newly created Clock-of-Change-API directory (`cd Clock-of-Change-API` in the console)
 3. Run `docker-compose up`. This will build the Docker container on first startup and run it. This can take a while, but after some time you should see the Clock of Change ticking.
-4. To create an initial API key and sample entries, run `docker-compose exec db seed.sh`. The initial API key you can use with your requests will have the value `secret`.
+4. To create an initial API key and sample entries, run `docker-compose exec db_api seed.sh`. The initial API key you can use with your requests will have the value `secret`.
 
 Now the Clock of Change API server is ready for usage at [http://127.0.0.1:1337](http://127.0.0.1:1337)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,20 @@
-version: '3'
+version: '3.5'
 
 services:
-  db:
+  db_api:
     image: mysql:5
     volumes:
       - coc_api_dbdata:/var/lib/mysql
       - ./seed.sh:/usr/local/bin/seed.sh
+    ports:
+     - 3306:3306
+    networks:
+      - coc_network
     environment:
       MYSQL_ROOT_PASSWORD: clockofchangepw
       MYSQL_DATABASE: clock_of_change
       MYSQL_USER: coc
       MYSQL_PASSWORD: 123456
-    ports:
-     - 3306:3306
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
 
   mailhog:
@@ -21,6 +23,8 @@ services:
     ports:
       - 1025:1025
       - 8025:8025
+    networks:
+      - coc_network
 
   coc-api:
     image: clock-of-change-api
@@ -31,8 +35,10 @@ services:
       - /home/node/coc-api/node_modules
     ports:
       - 1337:1337
+    networks:
+      - coc_network
     environment:
-      - MYSQL_HOST=db
+      - MYSQL_HOST=db_api
       - MYSQL_DB=clock_of_change
       - MYSQL_USER=coc
       - MYSQL_PASS=123456
@@ -41,9 +47,13 @@ services:
       - MAIL_USER=mailer
       - MAIL_PASS=123456
     depends_on:
-      - db
+      - db_api
       - mailhog
-    command: bash -c "wait-on tcp:db:3306 && db-migrate up && npm run start"
+    command: bash -c "wait-on tcp:db_api:3306 && db-migrate up && npm run start"
 
 volumes:
   coc_api_dbdata:
+
+networks:
+  coc_network:
+    name: coc_network


### PR DESCRIPTION
Close #28 

---

Create new Docker network coc_network and let Docker services join network.
This is issue also exists for the CoC Frontend (Human-Connection/Clock-of-Change-Frontend#5). If both are merged, Backend and Frontend are in the same network an can access each other.