### PR TITLE
Fix relative paths for uploads

### DIFF
--- a/core/entryController.js
+++ b/core/entryController.js
@@ -108,7 +108,7 @@ exports.createEntry = function(req, res) {
         requiredFields  = ['email', 'firstname', 'anon', 'message'],
         allowedFields   = ['email', 'firstname', 'lastname', 'anon', 'message', 'country', 'beta', 'newsletter', 'pax'];
 
-    form.uploadDir      = './uploads/';
+    form.uploadDir      =  __dirname + '/../uploads/';
     form.keepExtensions = true;
     form.maxFields      = 5;
     form.maxFieldsSize  = 2 * 1024 * 1024;

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const app = express();
 
 // config
 app.set('view engine', 'ejs');
-app.use('/uploads', express.static('uploads'));
+app.use('/uploads', express.static(__dirname + '/uploads'));
 app.use(bodyParser.urlencoded({
     extended: false
 }));


### PR DESCRIPTION
Fix relative paths for uploads, so uploading and serving profile images works with any user running the node server.

When deploying the current code and running it with my user via pm2, I had the problem that the uploaded files couldn't be accessed an served.
In order to fix this, I had to change the paths, taking the current directory into account. See also https://expressjs.com/en/starter/static-files.html (last paragraph).

This is the code that I changed on the server to make it work. For consistency of course I also update the git repo with the code.